### PR TITLE
Add from_str function in enum Resource

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ readme = "README.md"
 
 [dependencies]
 libc = "^0.2"
+thiserror = "1.0.20"
 cfg-if = "0.1.9"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,17 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error("rlimit error: {0}")]
+pub struct RlimitsError(pub(crate) String);
+
+impl From<&str> for RlimitsError {
+    fn from(arg: &str) -> Self {
+        Self(arg.to_string())
+    }
+}
+
+impl From<String> for RlimitsError {
+    fn from(arg: String) -> Self {
+        Self(arg)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@
 #[macro_use]
 extern crate cfg_if;
 
+pub mod errors;
+
 cfg_if! {
     if #[cfg(all(target_os = "linux", target_env = "gnu"))]{
         use libc::__rlimit_resource_t as __resource_t;
@@ -39,6 +41,8 @@ cfg_if! {
         use libc::c_int as __resource_t;
     }
 }
+
+use crate::errors::RlimitsError;
 
 use libc::rlim_t as __rlim_t;
 use libc::rlimit as __rlimit;
@@ -164,6 +168,32 @@ impl Resource {
     #[inline(always)]
     pub fn get(&self) -> std::io::Result<(rlim, rlim)> {
         getrlimit(*self)
+    }
+}
+
+impl std::str::FromStr for Resource {
+    type Err = RlimitsError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "RLIMIT_AS" => Ok(Resource::AS),
+            "RLIMIT_CORE" => Ok(Resource::CORE),
+            "RLIMIT_CPU" => Ok(Resource::CPU),
+            "RLIMIT_DATA" => Ok(Resource::DATA),
+            "RLIMIT_FSIZE" => Ok(Resource::FSIZE),
+            "RLIMIT_LOCKS" => Ok(Resource::LOCKS),
+            "RLIMIT_MEMLOCK" => Ok(Resource::MSGQUEUE),
+            "RLIMIT_MSGQUEUE" => Ok(Resource::MSGQUEUE),
+            "RLIMIT_NICE" => Ok(Resource::NICE),
+            "RLIMIT_NOFILE" => Ok(Resource::NOFILE),
+            "RLIMIT_NPROC" => Ok(Resource::NPROC),
+            "RLIMIT_RSS" => Ok(Resource::RSS),
+            "RLIMIT_RTPRIO" => Ok(Resource::RTPRIO),
+            "RLIMIT_RTTIME" => Ok(Resource::RTTIME),
+            "RLIMIT_SIGPENDING" => Ok(Resource::SIGPENDING),
+            "RLIMIT_STACK" => Ok(Resource::STACK),
+            _ => Err(format!("invalid rlimit: {}", s).into()),
+        }
     }
 }
 


### PR DESCRIPTION
I would like to add FromStr's from_str method in the enum Resource.
If the enum Resource has the from_str method, the Resource can convert from string to the own Resource type.
This feature is useful when retrieving the RLIMIT flags of string from a setting file and converting them to the Resource type.