### PR TITLE
Add 'documentation' to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Nugine <nugine@foxmail.com>"]
 edition = "2018"
 description = "A simple wrapper for getrlimit and setrlimit."
 repository = "https://github.com/Nugine/rlimit/"
+documentation = "https://docs.rs/rlimit/"
 license = "MIT"
 readme = "README.md"
 keywords = ["rlimit", "unix", "syscall"]


### PR DESCRIPTION
This makes crates.io adding a link to it.